### PR TITLE
Force array type on some properties to match API schema

### DIFF
--- a/server/graph/helpers/pwPropParser.js
+++ b/server/graph/helpers/pwPropParser.js
@@ -86,6 +86,8 @@ class PWPropParser {
             ],
         ]);
 
+        const forceArray = val => Array.isArray(val) ? val : [val];
+
         this._sanitizers = new Map([
             [
                 'addictionPotential',
@@ -94,6 +96,22 @@ class PWPropParser {
             [
                 'toxicity',
                 val => val.map(item => this._sanitizeText(item)),
+            ],
+            [
+                'uncertainInteractions',
+                forceArray,
+            ],
+            [
+                'unsafeInteractions',
+                forceArray,
+            ],
+            [
+                'dangerousInteractions',
+                forceArray,
+            ],
+            [
+                'effects',
+                forceArray,
             ],
         ]);
     }


### PR DESCRIPTION
The API schema specifies that an array is returned for `uncertainInteractions`, `unsafeInteractions`, `dangerousInteractions` and `effects`. When only one item is returned by MediaWiki, a single item is returned instead of an array with a single item. As a result, the GraphQL API returns null due to type mismatch. Example: dangerous interactions of LSD.

Alternative considered: Remove call to `_flattenIfNeeded()` [here](https://github.com/psychonautwiki/bifrost/blob/fd62f6e7d83335302fc82e89eb06f407beffc491/server/graph/helpers/smwDataArbitrator.js#L51). However, seems to cause too many issues with other properties.

